### PR TITLE
Fixed bug, Tensorflow 1.12.0: attention weights remains equal 1 for context and aspects during training

### DIFF
--- a/model.py
+++ b/model.py
@@ -48,10 +48,12 @@ class IAN(tf.keras.Model):
         context_avg = tf.reduce_mean(context_outputs, 1)
 
         aspect_att = tf.nn.softmax(tf.nn.tanh(tf.einsum('ijk,kl,ilm->ijm', aspect_outputs, self.aspect_w,
-                                                        tf.expand_dims(context_avg, -1)) + self.aspect_b))
+                                                        tf.expand_dims(context_avg, -1)) + self.aspect_b),
+                                   axis=1)
         aspect_rep = tf.reduce_sum(aspect_att * aspect_outputs, 1)
         context_att = tf.nn.softmax(tf.nn.tanh(tf.einsum('ijk,kl,ilm->ijm', context_outputs, self.context_w,
-                                                         tf.expand_dims(aspect_avg, -1)) + self.context_b))
+                                                         tf.expand_dims(aspect_avg, -1)) + self.context_b),
+                                    axis=1)
         context_rep = tf.reduce_sum(context_att * context_outputs, 1)
 
         rep = tf.concat([aspect_rep, context_rep], 1)


### PR DESCRIPTION
I have experiment with IAN in [AREkit](https://github.com/nicolay-r/AREkit) framework for sentiment attitudes extraction (this implementation has been embedded into toolkit).
The problem was that all the weights within a context/aspects remains equal 1.
The latter leads to that only last peceptron layer changes during training process.
All the other hidden states remains the same as i think  due to the abscense of a variation and hence a gradient for back prop.

Clarifying axes from 0 (by default, by `i` -- batch) to 1 ( `j` -- context words) (`ij` in einsum function notation) fixed the problem.

Suppose that the latter led to worse results since implementation become updated.
